### PR TITLE
Update PluginCreatorPlugin.Build.cs

### DIFF
--- a/Source/PluginCreatorPlugin/PluginCreatorPlugin.Build.cs
+++ b/Source/PluginCreatorPlugin/PluginCreatorPlugin.Build.cs
@@ -3,7 +3,7 @@ using System.IO;
  
 public class PluginCreatorPlugin : ModuleRules
 {
-    public PluginCreatorPlugin(TargetInfo Target)
+    public PluginCreatorPlugin(ReadOnlyTargetRules Target) : base(Target)
     {
         PrivateIncludePaths.AddRange(new string[] { "PluginCreatorPlugin/Private", "PluginCreatorPlugin/Private/UI", "PluginCreatorPlugin/Private/Helpers"  });
 


### PR DESCRIPTION
When I want to add current codes to my project (generate visual studio project files), it will appear error CS1729. After searching from the Internet, I found the solution in https://answers.unrealengine.com/questions/764146/unreal-build-tool-error-1.html worked:

In UE 4.16 engine switched from using ReadOnlyTargetRules from TargetInfo in constructor of your C# modules. In newer version you also have to call base contructor and pass that target(ReadOnlyTargetRules) here.